### PR TITLE
Don’t use global functions (breaking change).

### DIFF
--- a/make-bundle.js
+++ b/make-bundle.js
@@ -2,7 +2,7 @@ var code = require('coffee-script').compile(require('fs').readFileSync('react-co
 
 var options = {
   code: code,
-  exports: 'ReactCoffeescriptGlue',
+  exports: 'ReactGlue',
   dependencies: [{name: 'react', exports: 'React'},]
 };
 

--- a/react-coffeescript-glue.coffee
+++ b/react-coffeescript-glue.coffee
@@ -1,7 +1,9 @@
+ReactGlue = {}
+
 define_tag = (tag) ->
   return unless {}.hasOwnProperty.call(React.DOM, tag) && tag != 'injection'
 
-  window['_' + tag] = (attrs, children...) ->
+  ReactGlue[tag] = (attrs, children...) ->
     if Array.isArray(attrs)
       options = { className: '' }
       for attr in attrs
@@ -16,3 +18,5 @@ define_tag = (tag) ->
 
 
 define_tag tag for tag, method of React.DOM
+
+return ReactGlue

--- a/react-coffeescript-glue.js
+++ b/react-coffeescript-glue.js
@@ -6,7 +6,7 @@
     define(['react'], factory);
   }
   else {
-    var globalAlias = 'ReactCoffeescriptGlue';
+    var globalAlias = 'ReactGlue';
     var namespace = globalAlias.split('.');
     var parent = root;
     for ( var i = 0; i < namespace.length-1; i++ ) {
@@ -21,14 +21,16 @@
   }
 
   var _bundleExports = (function() {
-  var define_tag, method, tag, _ref,
+  var ReactGlue, define_tag, method, tag, _ref,
     __slice = [].slice;
+
+  ReactGlue = {};
 
   define_tag = function(tag) {
     if (!({}.hasOwnProperty.call(React.DOM, tag) && tag !== 'injection')) {
       return;
     }
-    return window['_' + tag] = function() {
+    return ReactGlue[tag] = function() {
       var attr, attrs, children, key, options, value, _i, _len, _ref, _ref1;
       attrs = arguments[0], children = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
       if (Array.isArray(attrs)) {
@@ -58,6 +60,8 @@
     method = _ref[tag];
     define_tag(tag);
   }
+
+  return ReactGlue;
 
 }).call(this);
 


### PR DESCRIPTION
Since that doesn’t play well with certain package managers, such as server-side CommonJS in Node.js.

Instead I propose exposing an object that can be used using CommonJS, AMD, or using globals (`window.ReactGlue`).

If you really want to use globals for convenience, you can still do something like `_.extend(window, ReactGlue)`.
